### PR TITLE
Disable relative line numbers in buffer window

### DIFF
--- a/autoload/buffergator.vim
+++ b/autoload/buffergator.vim
@@ -679,6 +679,7 @@ function! s:NewCatalogViewer(name, title)
         setlocal nolist
         setlocal noinsertmode
         setlocal nonumber
+        setlocal norelativenumber
         setlocal cursorline
         setlocal nospell
         setlocal matchpairs=""


### PR DESCRIPTION
`nolinenumber` is great, but if `relativenumber` is set, relative line numbers still show up in the buffer window.

I think the buffer window looks nicer without any line numbering at all, but that might just be me :sweat_smile: 

Great plugin!